### PR TITLE
Enable metadata.json for tcpd

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,0 +1,16 @@
+{
+  "name": "twopence-tcpd",
+  "summary": "Test suite for tcpd",
+  "description": "SLEnkins test suite for tcpd janitor for incoming TCP connections.",
+  "status": "ready",
+  "maintainer": ["Olaf Kirch <okirch@suse.com>"],
+  "rpm": ["twopence-tcpd", "twopence-tcpd-control"],
+  "arch": ["noarch"],
+  "product": "tcpd",
+  "fate": null,
+  "bnc": null,
+  "updated_at": "2016-03-14 16:08:00 UTC",
+  "tags": ["slenkins"],
+  "nodes": ["client", "server"],
+  "incompatible": []
+}


### PR DESCRIPTION
Hi Olaf @okirch ,

i'm adding the file metadata.json to twopence.suites.

As you see, this are meta-information about the testsuites.

i will send you a mail with a short introduction about metadata project
